### PR TITLE
Fix for  vulnerable dependency path

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "mime": "~1.3.4",
     "node-df": "crafatar/node-df",
     "redis": "~2.5.2",
-    "request": "~2.69.0",
+    "request": "~2.74.0",
     "toobusy-js": "~0.4.2"
   },
   "devDependencies": {


### PR DESCRIPTION
crafatar currently has a 1 vulnerable dependency paths, introducing 1 different types of known vulnerabilities.

This PR fixes vulnerable dependency, [ReDos vulnerability](https://snyk.io/vuln/npm:tough-cookie:20160722) in the `tough-cookie` dependency.

You can see [Snyk test report](https://snyk.io/test/github/crafatar/crafatar) of this project for details. 

This PR changes `Package.json` to upgrade `request` to the newer 2.74.0 version, and will fix the vulnerability.

You can get alerts and fix PRs for future vulnerabilities for free by [watching this repo with Snyk](https://snyk.io/add).

Stay Secure,
The Snyk Team
