### PR TITLE
Change link in status header

### DIFF
--- a/lib/public/javascript/crafatar.js
+++ b/lib/public/javascript/crafatar.js
@@ -52,7 +52,7 @@ xhr.onload = function() {
     var warn = document.createElement("div");
     warn.setAttribute("class", "alert alert-warning");
     warn.setAttribute("role", "alert");
-    warn.innerHTML = "<h5>Mojang issues</h5> Mojang's servers are having trouble <i>right now</i>, this may affect requests at Crafatar. <small><a href=\"https://twitter.com/mojangstatus\" target=\"_blank\">check status</a>";
+    warn.innerHTML = "<h5>Mojang issues</h5> Mojang's servers are having trouble <i>right now</i>, this may affect requests at Crafatar. <small><a href=\"https://mc-heads.net/mcstatus\" target=\"_blank\">check status</a>";
     document.querySelector("#alerts").appendChild(warn);
   }
 };

--- a/lib/public/javascript/crafatar.js
+++ b/lib/public/javascript/crafatar.js
@@ -52,7 +52,7 @@ xhr.onload = function() {
     var warn = document.createElement("div");
     warn.setAttribute("class", "alert alert-warning");
     warn.setAttribute("role", "alert");
-    warn.innerHTML = "<h5>Mojang issues</h5> Mojang's servers are having trouble <i>right now</i>, this may affect requests at Crafatar. <small><a href=\"https://help.mojang.com\" target=\"_blank\">check status</a>";
+    warn.innerHTML = "<h5>Mojang issues</h5> Mojang's servers are having trouble <i>right now</i>, this may affect requests at Crafatar. <small><a href=\"https://twitter.com/mojangstatus\" target=\"_blank\">check status</a>";
     document.querySelector("#alerts").appendChild(warn);
   }
 };


### PR DESCRIPTION
[Mojang's help page](https://help.minecraft.net) has been updated and no longer shows the status indicators. I changed the link to go to [mc-heads.net's status page](https://mc-heads.net/mcstatus/), as that's a great site in my opinion. I can change it to \@MojangSupport on twitter if you want, let me know here.